### PR TITLE
Markdown file updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,167 @@
 # W3C Sustainable Web Interest Group
 Welcome to the repository for the [W3C Sustainable Web Interest Group](https://www.w3.org/groups/ig/sustainableweb/).
 
+## Schedule
+<table>
+	<thead>
+		<tr>
+			<th>Date</th>
+			<th>Details</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Mar 15 2026</td>
+			<td>Wide review and other W3C horizontal review updates are ready for inclusion in WSG.</td>
+		</tr>
+		<tr>
+			<td rowspan="2">Apr 15 2026</td>
+			<td>TAG updates ready for inclusion in WSG.</td>
+		</tr>
+		<tr>
+			<td>IG begins work on new charter (6 months planning).</td>
+		</tr>
+		<tr>
+			<td rowspan="2">May 15 2026</td>
+			<td>IG completes initial work on supplements prior to WSG submission.</td>
+		</tr>
+		<tr>
+			<td>IG finalizes workflow changes it can affect, publishing an approach so that other groups can adopt.</td>
+		</tr>
+		<tr>
+			<td rowspan="2">Jun 15 2026</td>
+			<td>WSG is submitted to W3C for NOTE status.</td>
+		</tr>
+		<tr>
+			<td>IG begins discussion of educational materials, outreach, tooling, etc, to broaden awareness.</td>
+		</tr>
+		<tr>
+			<td rowspan="2">Jul 15 2026</td>
+			<td>WSG is readied and submitted for STMT (statement) status (See reminder for Chairs/Editors).</td>
+		</tr>
+		<tr>
+			<td>Agree on finalized charter, submit to strategy team for review (HR / TiLT, etc), then submit to AC.</td>
+		</tr>
+		<tr>
+			<td>Oct 31 2026</td>
+			<td>Our charter ends.</td>
+		</tr>
+	</tbody>
+</table>
+
+**Note:** Horizontal review is ongoing and wide review from external parties have been accepted at all stages of WSGs development.
+
+**Reminder for Chairs/Editors:** 6.4.3 of W3C Process states that during the statement review period, notes must NOT be updated. As editing of any file WILL trigger a new spec release in Echidna (automated publishing), NO merges of PR's / direct edits should be allowed during this phase.
+
+## Statistics
+
+- **71** Guidelines covering UX, Web Development, Infrastructure, and Business/Product Strategy.
+- **196** Success criteria to meet the guidelines on various aspects of sustainability.
+- **138** Advisory Techniques within STAR providing guidance to meet WSG success criteria.
+- **2,500+** Resources (URLs) to reinforce and assist with implementation of WSG guidelines.
+- **500+** pages worth of sustainability material (**100** of which exist within WSG).
+- **50** content filters based upon **4** different sustainability categories.
+- **200+** contributors from over **25** nations around the world.
+
+## Work
+
+The chartered focus of the [W3C Sustainable Web Interest Group](https://www.w3.org/groups/ig/sustainableweb/) is the development of Web Sustainability Guidelines (WSG) and its deliverables.
+
+Links to relevant documents (based on the CG Draft Report) can be found below.
+
+**Guidelines:**
+<table>
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>Status</th>
+			<th>Date</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td><a href="https://www.w3.org/TR/web-sustainability-guidelines/">Web Sustainability Guidelines</a> (WSG)</td>
+			<td>W3C Group Note Draft</td>
+			<td>03 Jul 2026</td>
+		</tr>
+	</tbody>
+</table>
+
+**Other Deliverables:**
+<table>
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>Status</th>
+			<th>Date</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td><a href="https://w3c.github.io/sustainableweb-ig/docs/star.html">Sustainable Tooling And Reporting</a> (STAR)</td>
+			<td>W3C Editors Draft</td>
+			<td>03 Jul 2026</td>
+		</tr>
+		<tr>
+			<td><a href="https://w3c.github.io/sustainableweb-ig/docs/resources.html">WSG Resources</a></td>
+			<td>W3C Editors Draft</td>
+			<td>03 Jul 2026</td>
+		</tr>
+		<tr>
+			<td><a href="https://w3c.github.io/sustainableweb-ig/docs/policies.html">Web Sustainability Laws and Policies</a></td>
+			<td>W3C Editors Draft</td>
+			<td>03 Jul 2026</td>
+		</tr>
+		<tr>
+			<td><a href="https://w3c.github.io/sustainableweb-impact">WSG Impact Measurement</a></td>
+			<td>W3C Editors Draft</td>
+			<td>26 June 2026</td>
+		</tr>
+		<tr>
+			<td><a href="https://w3c.github.io/sustainableweb-ig/docs/benefits.html">WSG Benefits</a></td>
+			<td>W3C Editors Draft</td>
+			<td>03 Jul 2026</td>
+		</tr>
+		<tr>
+			<td><a href="https://w3c.github.io/sustainableweb-ig/docs/glance.html">WSG At A Glance</a></td>
+			<td>W3C Editors Draft</td>
+			<td>03 Jul 2026</td>
+		</tr>
+		<tr>
+			<td><a href="https://w3c.github.io/sustainableweb-ig/docs/quickref.html">WSG Quick Reference</a></td>
+			<td>W3C Editors Draft</td>
+			<td>03 Jul 2026</td>
+		</tr>
+		<tr>
+			<td><a href="https://w3c.github.io/sustainableweb-wsg/guidelines.json">WSG JSON API</a></td>
+			<td>JSON API</td>
+			<td>03 Jul 2026</td>
+		</tr>
+		<tr>
+			<td><a href="https://w3c.github.io/sustainableweb-impact/impact.json">WSG Impact JSON API</a></td>
+			<td>JSON API</td>
+			<td>03 Jul 2026</td>
+		</tr>
+		<tr>
+			<td><a href="https://w3c.github.io/sustainableweb-ig/docs/star.json">STAR JSON API</a></td>
+			<td>JSON API</td>
+			<td>03 Jul 2026</td>
+		</tr>
+		<tr>
+			<td><a href="https://github.com/w3c/sustainableweb-ig/tree/main/docs/test-suite">STAR Test Suite</a></td>
+			<td>Test Suite</td>
+			<td>03 Jul 2026</td>
+		</tr>
+	</tbody>
+</table>
+
 ## Mission
 
 Digital Sustainability is an evolving field that is complex and undergoing significant change due to technological advances such as Artificial Intelligence and legislative shifts. The complexity of these rapid changes increases the need and urgency to provide guidance for those expected to meet climate-related goals and targets.
 
 The mission of the [W3C Sustainable Web Interest Group](https://www.w3.org/groups/ig/sustainableweb/) is to improve digital sustainability so that the Web works better for all people and the planet.
 
-We do this through advancing the development of the [Web Sustainability Guidelines (WSG)](https://www.w3.org/TR/web-sustainability-guidelines/), its [supplementary materials](https://github.com/w3c/sustainableweb-wsg), and advocacy work (in digital sustainability) to educate and advise on any implementations of our work and its importance in the context of their organizations.
+We do this through advancing the development of the [Web Sustainability Guidelines (WSG)](https://www.w3.org/TR/web-sustainability-guidelines/), its supplementary materials, and advocacy work (in digital sustainability) to educate and advise on any implementations of our work and its importance in the context of their organizations.
 
 See also the [Sustainable Web Interest Group Charter](https://www.w3.org/2024/10/ig-sustainableweb-charter.html).
 
@@ -24,27 +178,39 @@ As a W3C Interest group we continue the work of this Community Group, further im
 ## Participate
 
 ### Frequently Asked Questions
-
-What work is the Interest Group producing?
-> We are currently creating a set of international guidelines that aim to advocate advisory best practices around digital sustainability. With coverage around user-experience design, Web development, development operations, and business/product strategy; the Web Sustainability Guidelines (WSG) aims to prioritize people and the planet in the product creation cycle.
-> 
-> Using evidence-based methodologies, this set of guidelines will enable implementers to reduce their digital carbon footprint and practice sustainable design and development, meeting regulatory compliance targets as well as industry best practices.
-
-Who should participate in this group?
-> The Sustainable Web Interest Group encourages active participation from a diverse community. You should consider participating in this Interest Group, in particular, if you are in one of the following communities:
-> - Vendors of Web browsers seeking to improve the sustainability of the browsing experience.
-> - Organizations and agencies that focus on marketing, web design / development, devops, and related digital services.
-> - Individuals or organizations with a background or interest in promoting and / or implementing digital sustainability.
-> - Sustainability-specific organizations, especially those looking to improve reporting and practices or those that serve our industry.
-> - Software vendors or open source projects developing digital sustainability solutions utilizing the WSGs.
-> - Government organizations seeking to standardize or develop policies around digital sustainability.
-> - Academic researchers or scientists with an interest in digital sustainability and eco-design.
-> - Industry association or standards body representatives.
-
-How can I join the group as an official participant?
-> - If you are affiliated with a [W3C member organization](https://www.w3.org/Consortium/Member/List), consider [joining our Interest Group](https://www.w3.org/groups/ig/sustainableweb/join/) (you will require a W3C account to participate).
-> - If you do not work for a W3C Member organization, please first consider whether your employer can [join W3C](https://www.w3.org/Consortium/join) and [get the benefits of Membership](https://www.w3.org/Consortium/membership-benefits).
-> - If that is not an option and you think that you have the expertise and availability to participate, please check our [Invited Expert Policy](ie-policy.md) for [becoming a member](https://www.w3.org/groups/ig/sustainableweb/join/) of our Interest Group.
+<details>
+	<summary>What work is the Interest Group producing?</summary>
+	<blockquote>
+		<p>We are currently creating a set of international guidelines that aim to advocate advisory best practices around digital sustainability. With coverage around user-experience design, Web development, development operations, and business/product strategy; the Web Sustainability Guidelines (WSG) aims to prioritize people and the planet in the product creation cycle.</p>
+		<p>Using evidence-based methodologies, this set of guidelines will enable implementers to reduce their digital carbon footprint and practice sustainable design and development, meeting regulatory compliance targets as well as industry best practices.</p>
+	</blockquote>
+</details>
+<details>
+	<summary>Who should participate in this group?</summary>
+	<blockquote>
+		<p>The Sustainable Web Interest Group encourages active participation from a diverse community. You should consider participating in this Interest Group, in particular, if you are in one of the following communities:</p>
+		<ul>
+			<li>Vendors of Web browsers seeking to improve the sustainability of the browsing experience.</li>
+			<li>Organizations and agencies that focus on marketing, web design / development, devops, and related digital services.</li>
+			<li>Individuals or organizations with a background or interest in promoting and / or implementing digital sustainability.</li>
+			<li>Sustainability-specific organizations, especially those looking to improve reporting and practices or those that serve our industry.</li>
+			<li>Software vendors or open source projects developing digital sustainability solutions utilizing the WSGs.</li>
+			<li>Government organizations seeking to standardize or develop policies around digital sustainability.</li>
+			<li>Academic researchers or scientists with an interest in digital sustainability and eco-design.</li>
+			<li>Industry association or standards body representatives.</li>
+		</ul>
+	</blockquote>
+</details>
+<details>
+	<summary>How can I join the group as an official participant?</summary>
+	<blockquote>
+		<ul>
+			<li>If you are affiliated with a <a href="https://www.w3.org/Consortium/Member/List">W3C member organization</a>, consider <a href="https://www.w3.org/groups/ig/sustainableweb/join/">joining our Interest Group</a> (you will require a W3C account to participate).</li>
+			<li>If you do not work for a W3C Member organization, please first consider whether your employer can <a href="https://www.w3.org/Consortium/join">join W3C</a> and <a href="https://www.w3.org/Consortium/membership-benefits">get the benefits of Membership</a>.</li>
+			<li>If that is not an option and you think that you have the expertise and availability to participate, please check our <a href="ie-policy.md">Invited Expert Policy</a> for <a href="https://www.w3.org/groups/ig/sustainableweb/join/">becoming a member</a> of our Interest Group.</li>
+		</ul>
+	</blockquote>
+</details>
 
 ### Methods
 
@@ -54,7 +220,7 @@ If you wish to contribute, the below methods are how our group facilitates the d
 
 This Interest Group primarily conducts its technical work through GitHub. We welcome contributions through issue-raising and pull requests on our publicly available repositories for both our [Interest Group](https://github.com/w3c/sustainableweb-ig/) and the [Web Sustainability Guidelines](https://github.com/w3c/sustainableweb-wsg/) (WSG).
 
- - Issue Tracker ([Interest Group](https://github.com/w3c/sustainableweb-ig/issues) / [WSG](https://github.com/w3c/sustainableweb-wsg/issues))
+- Issue Tracker ([Interest Group](https://github.com/w3c/sustainableweb-ig/issues) / [WSG](https://github.com/w3c/sustainableweb-wsg/issues))
 
 #### Feedback
 
@@ -62,10 +228,10 @@ We welcome individuals who are unaffiliated with our group to provide feedback o
 
 Examples of this may include:
 
- - Providing feedback and commentary through articles or blog posts.
- - Showcasing implementations, test cases, and early adoption of our work.
- - Speaking about or presenting materials that will educate and inform.
- - Creating tooling to enable implementations of the WSGs.
+- Providing feedback and commentary through articles or blog posts.
+- Showcasing implementations, test cases, and early adoption of our work.
+- Speaking about or presenting materials that will educate and inform.
+- Creating tooling to enable implementations of the WSGs.
 
 #### Meetings
 
@@ -93,20 +259,79 @@ You can find more information about our outreach efforts, and where we spot exte
 
 The co-chairs of the Sustainable Web Interest Group are:
 
- - **Ines Akrap** (Storyblok)
- - **Tim Frick** (Mightybytes)
- - **Mike Gifford** (CivicActions)
+- **Ines Akrap** (Storyblok)
+- **Tim Frick** (Mightybytes)
+- **Mike Gifford** (CivicActions)
 
 Lead Editor of the Web Sustainability Guidelines (WSG) is:
 
- - **Alexander Dawson** (Invited Expert)
+- **Alexander Dawson** (Invited Expert)
 
 Editor of the Web Sustainability Guidelines (WSG) is:
 
- - **Rose Newell** (Invited Expert)
+- **Rose Newell** (Invited Expert)
 
 The W3C Team Contact for the group is:
 
- - **Tzviya Siegman** (W3C)
+- **Tzviya Siegman** (W3C)
 
 See also the [list of participants](https://www.w3.org/groups/ig/sustainableweb/participants/) involved in the Interest Group.
+
+## JSON APIs
+
+We have three JSON APIs which are kept in sync with the changes occurring within our [specification](https://w3c.github.io/sustainableweb-wsg/guidelines.json), [impact](https://w3c.github.io/sustainableweb-impact/impact.json) and [STAR](https://w3c.github.io/sustainableweb-ig/docs/star.json).
+
+These documents are reachable via GitHub pages and can be queried using JavaScript to embed our data within your client of choice.
+
+**WSG** (*guidelines.json*)
+```js
+category[1].guidelines[0].guideline = "Identify, assess, disclose, review, and mitigate sustainability impacts"
+```
+**WSG Impact** (*impact.json*)
+```js
+category[1].guidelines[0].impactRatings[0].people = "Indeterminate"
+```
+**STAR** (*star.json*)
+```js
+category[1].techniques[0].title = "Produce a List of Factors To Monitor for Sustainability Impacts"
+```
+
+One method of reaching the API could be through code similar to the below (customize to your requirements):
+
+```js
+fetch("https://w3c.github.io/sustainableweb-wsg/guidelines.json")
+  .then((res) => res.json())
+  .then((data) => {
+    console.log(`The First UX Guideline Title is ${data.category[1].guidelines[0].guideline}`); });
+```
+
+**Note:** To match a WSG guideline to a STAR technique, you can match the guideline `testable` anchor hash (WSG JSON API) to the technique `id` (STAR JSON API).
+
+## Test Suite
+
+We have a [Test Suite](https://github.com/w3c/sustainableweb-wsg/tree/main/docs/test-suite) which is used to showcase machine testability (as denoted in [STAR](https://w3c.github.io/sustainableweb-ig/docs/star.html)) for Web Sustainability Guidelines (WSG). The template structure for the file uses common W3C conventions for test cases to maintain interoperability for tooling that wishes to align our work with their own.
+
+Key concepts of note include:
+- Each title element contains a short identifier for the test.
+- The rel="author" link element contains details of who created that test.
+- The rel="help" link element links to the WSG guideline it relates to.
+- The name="flags" meta element identifies any requirements the test may have such as an external file (**asset**), scripting (**JavaScript**), user-involvement (**interaction**), or if it is trying to disprove something (**invalid**).
+- The name="assert" meta tag explains which **STAR** technique it relates to by title.
+- The conditions of passing are what requirements are necessary to pass the technique (and thus the success criteria).
+
+## Resources
+
+Below are some handy links for contributors to our project:
+
+- [Charter Template](https://w3c.github.io/charter-drafts/charter-template.html) ([HTML Source](https://github.com/w3c/charter-drafts/blob/gh-pages/charter-template.html))
+- [How to do Wide Review](https://www.w3.org/Guide/documentreview/)
+- [Policies and legal information](https://www.w3.org/policies/)
+- [Pubrules](https://www.w3.org/pubrules/) ([Documentation](https://www.w3.org/pubrules/doc/))
+- [QA Framework](https://www.w3.org/TR/qaframe-spec/)
+- [Repository Templates](https://github.com/w3c/ash-nazg/tree/master/templates)
+- [ReSpec Documentation](https://respec.org/docs/)
+- [Spec Prod](https://w3c.github.io/spec-prod/) ([Specberus](https://github.com/w3c/specberus) / [Echidna](https://github.com/w3c/echidna/wiki/How-to-use-Echidna) )
+- [TAG Explainers](https://tag.w3.org/explainers/)
+- [The Art of Consensus](https://www.w3.org/Guide/)
+- [W3C Manual of Style](https://www.w3.org/Guide/manual-of-style/)
+- [W3C Process for Busy People](https://github.com/w3c/wg-effectiveness/blob/main/process.md)

--- a/explainer.md
+++ b/explainer.md
@@ -1,0 +1,42 @@
+# Web Sustainability Guidelines Explainer
+
+Participate / where to discuss more: [WSG Issue tracker](https://github.com/w3c/sustainableweb-wsg/issues) / [Impact measurement issue tracker](https://github.com/w3c/sustainableweb-impact/issues) / [Sustainable Web Interest Group](https://www.w3.org/groups/ig/sustainableweb/) / [\#sustainability channel on W3C Slack](https://w3ccommunity.slack.com/archives/C02JETQAQG4)
+
+## The problem we’re solving
+
+The digital industry has a significant sustainability impact, which affects people worldwide: 
+
+- responsible for between **2-5%** of global emissions \[[ICT-IMPACT](https://w3c.github.io/sustainableweb-ig/docs/glance.html#bib-ict-impact)\] \[[EUC](https://w3c.github.io/sustainableweb-ig/docs/glance.html#bib-euc)\] \[[8BT](https://w3c.github.io/sustainableweb-ig/docs/glance.html#bib-8bt)\] \[[UN](https://w3c.github.io/sustainableweb-ig/docs/glance.html#bib-un)\] \[[WB](https://w3c.github.io/sustainableweb-ig/docs/glance.html#bib-wb)\], more than those of the aviation industry.   
+- since the Paris Agreement, average web page sizes have increased by over **100%** on desktop and **180%** on mobile \[[PAGE-WEIGHT](https://w3c.github.io/sustainableweb-ig/docs/glance.html#bib-page-weight)\].   
+- between 2015 and 2021, internet users increased by **60%**, whilst internet traffic increased by **440%** \[[DATA](https://w3c.github.io/sustainableweb-ig/docs/glance.html#bib-data)\]. 
+
+There is plenty of opportunity to reduce that impact, and many organizations want to do so. Reasons include cost-saving, legal compliance and corporate responsibility.
+
+Hands-on advice on how to make digital products and services more sustainable is not currently available in a systematic, widely reviewed, openly developed, and standardized format.
+
+## Approach
+
+[Web Sustainability Guidelines (WSG)](https://www.w3.org/TR/web-sustainability-guidelines/) help design and implement digital products and services that are more sustainable.
+
+WSG are designed to put people and planet first. They are best practices based on measurable, evidence-based research. They are also  cross-referenced [with other industry best practices](https://www.w3.org/TR/web-sustainability-guidelines/#relationships) such as the General Policy Framework for the Ecodesign of Digital Services and GR491.
+
+The guidelines can be used by individuals and organizations to improve products, and to show progress in their road to becoming more sustainable (the aim is "progress over perfection").
+
+## Practical use cases
+
+| Audience | They can use WSG to… |
+| :---- | :---- |
+| People making digital products and services (including web developers, user experience designers, infrastructure and system engineers, business strategists, product managers) | …make their products and services more sustainable. |
+| Organizations responsible for digital products and services, sustainability program leaders | …track their progress in improving sustainability. |
+| Authoring Tools and User Agents | …build tooling that helps improve sustainability into their products. |
+| Regulators and policy makers | …have a standardized way to understand what improving sustainability looks like. |
+
+## Alternatives Considered
+
+n/a 
+
+For content organization, currently by discipline, we previously considered organising by what's tested (website, system, tool), and by [principle](https://drive.google.com/file/d/1Fsw38rJ0IgF_Vhln6IrSG5YmO6zWk9Fu/view), like the Web Content Accessibility Guidelines’ POUR principles. We decided against those, as we considered a filtering system to be the best way for people to find what they want.
+
+## Accessibility, Internationalization, Privacy, and Security Considerations
+
+Where applicable, accessibility, internationalization, privacy, and security have been considered throughout the development of Web Sustainability Guidelines. [A list of guidelines to these areas](https://www.w3.org/TR/web-sustainability-guidelines/#considerations) is available.

--- a/minutes/2025-05-29.md
+++ b/minutes/2025-05-29.md
@@ -23,14 +23,14 @@
    - Product/Biz: this is the section that interfaces with the rest of the world. There are many new resources (Climate leaders v2, B Corp standards), We need to figure out if there is anything new to add.
 
 4. Community + News
-   - **WSG Update (Alex):** New [Resources Supplement](https://w3c.github.io/sustainableweb-wsg/resources.html) ([PR 67](https://github.com/w3c/sustainableweb-wsg/pull/67))
+   - **WSG Update (Alex):** New [Resources Supplement](https://w3c.github.io/sustainableweb-ig/docs/resources.html) ([PR 67](https://github.com/w3c/sustainableweb-wsg/pull/67))
      - WSG links to Resources in the document head (Supplements). - easier to maintain a separate document, useful resource on its own, makes WSG more evergreen
      - Each WSG SC cross-references ([example](https://w3c.github.io/sustainableweb-wsg/#external-variables)) to its Resources (URLs) via a “jump to section” feature (next to and works like testability for STAR).
      - WSG now has a new filter category (Standards) based on [relationships](https://w3c.github.io/sustainableweb-wsg/#relationships) found in references we currently have in the resources supplement.
      - Some SC’s were lacking evidence, so I researched and added more links.
        **Note:** more on the way, I’ve got a backlog of research & links to verify.
 
-     - [STAR techniques](https://w3c.github.io/sustainableweb-wsg/star.html#user-experience-design) are visually aligned to the WSG and grouped by SC.
+     - [STAR techniques](https://w3c.github.io/sustainableweb-ig/docs/star.html#user-experience-design) are visually aligned to the WSG and grouped by SC.
 
      - Non-destructive minor copy tweaks that apply globally to the WSG copy have been applied to help improve general readability. (thanks to Rose!)
 

--- a/minutes/2026-01-15.md
+++ b/minutes/2026-01-15.md
@@ -101,7 +101,7 @@ Jen Strickland, Tzviya Siegman, Thorsten Jonas
 
        - Sid: I was pushing for this agenda - Have we planned to create a visual representation of the framework? A step-by-step process to guide users in measuring the impact might help further and users will get a ready format in which to present their findings? For example, in training evaluation, we use frameworks that help evaluators follow a step-by-step process to evaluate training programs. Something similar can be done here, as it will make the process easier. It would be great if W3C only comes up with such a framework; otherwise, we would be bombarded by multiple frameworks, and people might get confused about which one to apply.
 
-       - Alex points to [STAR](https://w3c.github.io/sustainableweb-wsg/star.html#evaluation-methodology) for evaluation method
+       - Alex points to [STAR](https://w3c.github.io/sustainableweb-ig/docs/star.html#evaluation-methodology) for evaluation method
 
        - Sid: STAR looks like a good framework to present in workshops. 
 

--- a/minutes/2026-04-02.md
+++ b/minutes/2026-04-02.md
@@ -55,7 +55,7 @@ Eloisa Guerrero
 
      - Tim: Implement homework by June and include it in the spec itself.
 
-   - Earth Day - **20 days**, how to make some noise, given our progress? ([benefits doc](https://w3c.github.io/sustainableweb-wsg/benefits.html)?) - W3C blog post to share with your networks? Any other ideas?
+   - Earth Day - **20 days**, how to make some noise, given our progress? ([benefits doc](https://w3c.github.io/sustainableweb-ig/docs/benefits.html)?) - W3C blog post to share with your networks? Any other ideas?
 
      - Tim: We’re behind schedule, got great feedback on the spec and if there’s anything we want to do for Earth Day -- noise we want to make or any messaging, Tzviya mentioned the possibility of a draft for a blog post going on W3C. If anyone has any other ideas, the signal to noise ratio is very high but I think we have a really good story to tell.
 

--- a/minutes/2026-06-04.md
+++ b/minutes/2026-06-04.md
@@ -86,7 +86,7 @@ Sid
 
       - I will open this issue really soon and you let me know if there is anything.
 
-  - **How to handle** [****Resources****](https://w3c.github.io/sustainableweb-wsg/resources.html) **docs (longevity, readability, where should links go)**
+  - **How to handle** [****Resources****](https://w3c.github.io/sustainableweb-ig/docs/resources.html) **docs (longevity, readability, where should links go)**
 
     - Alex: Originally we had lot of resources embedded in documents. We know they go out of date and become problematic. The main doc is much safer.
 

--- a/minutes/2026-07-02.md
+++ b/minutes/2026-07-02.md
@@ -31,23 +31,23 @@ James
 
     - Impact
 
-      - Impact API document: [<https://w3c.github.io/sustainableweb-wsg/impact.html>]
+      - Impact API document: [<https://w3c.github.io/sustainableweb-impact/>]
 
       - This is the explanation of the API, to publish as a note. Group agrees.
 
       - It requires editing before a consensus process.
 
-      - **Team homework**: review and make comments on <https://w3c.github.io/sustainableweb-wsg/impact.html>
+      - **Team homework**: review and make comments on <https://w3c.github.io/sustainableweb-impact>
 
         - Feedback: open an issue.
 
   - To be published within a W3C Sustainability website in the future:
 
-    - [Resources/Benefit ](https://w3c.github.io/sustainableweb-wsg/resources.html)(to become Understanding? A la WCAG)
+    - [Resources/Benefit ](https://w3c.github.io/sustainableweb-ig/docs/resources.html)(to become Understanding? A la WCAG)
 
-      - [Laws and Policies](https://github.com/w3c/sustainableweb-wsg/blob/main/policies.html)
+      - [Laws and Policies](https://github.com/w3c/sustainableweb-ig/docs/policies.html)
 
-    - [Quick Ref](https://github.com/w3c/sustainableweb-wsg/blob/main/quickref.html) (checklist)
+    - [Quick Ref](https://github.com/w3c/sustainableweb-wsg/ig/docs/quickref.html) (checklist)
 
     - [Summaries here](https://www.w3.org/TR/web-sustainability-guidelines/#wsg-supporting-documents).
 

--- a/tagFilter.md
+++ b/tagFilter.md
@@ -21,7 +21,7 @@ The below attributes are **required** to be included within `<section>` elements
 
 ```html
 <section class="notoc" data-people="indeterminate" data-planet="indeterminate" data-prosperity="indeterminate" data-timeframe="medium" data-standard="AFNOR" data-considerations="Accessibility" data-categories="Compatibility, Ideation, KPIs, Patterns, Reporting, Research, Social Equity, UI, Usability">
-	<h4 id="identify-and-define">Success Criterion: Identify and define <span class="external"><a class="urls" href="https://w3c.github.io/sustainableweb-wsg/resources.html#UX02-1">Resources</a></span></h4>
+	<h4 id="identify-and-define">Success Criterion: Identify and define <span class="external"><a class="urls" href="https://w3c.github.io/sustainableweb-ig/docs/resources.html#UX02-1">Resources</a></span></h4>
 	<p>Primary and secondary target visitors are identified, and their needs are defined through quantitative or qualitative research, testing, or analytics, ensuring your visitors and affected communities remain a close part of the research and testing process.</p>
 </section>
 ```


### PR DESCRIPTION
This corrects lots of links RE the upcoming file shift.

In addition it moves some of the content like the schedule to the IG repo where our groups activities can be more routinely updated for when the NOTE goes to STMT status.